### PR TITLE
Added Snappy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ return [
     'disable_filter_columns' => false,
     'disable_file_name' => false,
     'disable_preview' => false,
+    'use_snappy' => false,
     'action_icon' => 'heroicon-o-document-download',
     'preview_icon' => 'heroicon-o-eye',
     'export_icon' => 'heroicon-o-download',
@@ -115,3 +116,31 @@ This package has two views:
 1. "components\table_view.blade.php" view is used for preview and as print template.
 
 2. "pdf.blade.php" view is used as pdf export template.
+
+## Using Snappy
+
+By default, this package uses [dompdf](https://github.com/barryvdh/laravel-dompdf) as pdf generator.
+
+If you want to use Snappy instead you need to install **barryvdh/laravel-snappy** to your project and configure it yourself. (See [barryvdh/laravel-snappy](https://github.com/barryvdh/laravel-snappy) for more information.)
+
+To use snappy for PDF exports:
+
+1. You can simply add ->snappy() to your actions.
+   
+```php
+FilamentExportBulkAction::make('export')
+    ->snappy()
+```
+or
+```php
+FilamentExportHeaderAction::make('export')
+    ->snappy()
+```
+2. You can update the config file to use it as default.
+```php
+[
+    ...
+    'use_snappy' => true,
+    ...
+]
+```

--- a/config/filament-export.php
+++ b/config/filament-export.php
@@ -9,6 +9,7 @@ return [
     'disable_file_name' => false,
     'disable_file_name_prefix' => false,
     'disable_preview' => false,
+    'use_snappy' => true,
     'action_icon' => 'heroicon-o-document-download',
     'preview_icon' => 'heroicon-o-eye',
     'export_icon' => 'heroicon-o-download',

--- a/src/Actions/Concerns/CanUseSnappy.php
+++ b/src/Actions/Concerns/CanUseSnappy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Actions\Concerns;
+
+trait CanUseSnappy
+{
+    protected bool $shouldUseSnappy = false;
+
+    public function snappy(bool $condition = true): static
+    {
+        $this->shouldUseSnappy = $condition;
+
+        return $this;
+    }
+
+    public function shouldUseSnappy(): bool
+    {
+        return $this->shouldUseSnappy;
+    }
+}

--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -8,6 +8,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFilterColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileName;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileNamePrefix;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanUseSnappy;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasAdditionalColumnsField;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasFilterColumnsField;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasDefaultFormat;
@@ -28,6 +29,7 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
     use CanDisableFilterColumns;
     use CanDisableFileName;
     use CanDisablePreview;
+    use CanUseSnappy;
     use HasAdditionalColumnsField;
     use HasFilterColumnsField;
     use HasDefaultFormat;

--- a/src/Actions/FilamentExportHeaderAction.php
+++ b/src/Actions/FilamentExportHeaderAction.php
@@ -7,6 +7,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFilterColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileName;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileNamePrefix;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanUseSnappy;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasAdditionalColumnsField;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasFilterColumnsField;
 use AlperenErsoy\FilamentExport\Actions\Concerns\HasDefaultFormat;
@@ -29,6 +30,7 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
     use CanDisableFileName;
     use CanDisableFileNamePrefix;
     use CanDisablePreview;
+    use CanUseSnappy;
     use HasAdditionalColumnsField;
     use HasFilterColumnsField;
     use HasDefaultFormat;

--- a/src/Concerns/CanUseSnappy.php
+++ b/src/Concerns/CanUseSnappy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Concerns;
+
+trait CanUseSnappy
+{
+    protected bool $shouldUseSnappy = false;
+
+    public function snappy(bool $condition = true): static
+    {
+        $this->shouldUseSnappy = $condition;
+
+        return $this;
+    }
+
+    public function shouldUseSnappy(): bool
+    {
+        return $this->shouldUseSnappy;
+    }
+}


### PR DESCRIPTION
You can now use [Snappy](https://github.com/barryvdh/laravel-snappy) as pdf generator. See readme for more information.