### PR TITLE
Fixed snappy config issues

### DIFF
--- a/config/filament-export.php
+++ b/config/filament-export.php
@@ -9,7 +9,7 @@ return [
     'disable_file_name' => false,
     'disable_file_name_prefix' => false,
     'disable_preview' => false,
-    'use_snappy' => true,
+    'use_snappy' => false,
     'action_icon' => 'heroicon-o-document-download',
     'preview_icon' => 'heroicon-o-eye',
     'export_icon' => 'heroicon-o-download',

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -124,7 +124,7 @@ class FilamentExport implements FromCollection, WithHeadings, WithTitle, WithCus
 
         $action->disablePreview(config('filament-export.disable_preview'));
 
-        $action->snappy(config('filament-export.use_snappy'));
+        $action->snappy(config('filament-export.use_snappy', false));
 
         $action->icon(config('filament-export.action_icon'));
 


### PR DESCRIPTION
I somehow kept use_snappy true in the config file and added default value for it to ensure backward compatibility.