### PR TITLE
Fix export excel failed

### DIFF
--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -282,7 +282,7 @@ class FilamentExport
                 } elseif ($column instanceof ViewColumn) {
                     $state = trim(preg_replace('/\s+/', ' ', strip_tags($column->render()->render())));
                 }
-                $item[$column->getName()] = $state;
+                $item[$column->getName()] = (string) $state;
             }
             array_push($items, $item);
         }


### PR DESCRIPTION
Currently the excel package (simple-excel / opensprout) will throw an exception if our data has null / object. 

This will prevent the exception by casting column value to string before sending it to the excel package.