### PR TITLE
Currently when trying to use ->withHiddenColumns() throws an error

### DIFF
--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -180,7 +180,7 @@ class FilamentExport
     {
         $action->fileNamePrefix($action->getFileNamePrefix() ?: $action->getTable()->getHeading());
 
-        $columns = $action->shouldShowHiddenColumns() ? $action->getLivewire()->getCachedcolumns() : $action->getTable()->getColumns();
+        $columns = $action->shouldShowHiddenColumns() ? $action->getLivewire()->getCachedTableColumns() : $action->getTable()->getColumns();
 
         $columns = collect($columns);
 


### PR DESCRIPTION
BadMethodCallException
PHP 8.1.6
Laravel 9.47.0
Method App\Filament\Resources\PatientResource\Pages\ListPatients::getCachedcolumns does not exist.

getCachedTableColumns fixes that.