### PR TITLE
Allow non-paginated tables to be exported

### DIFF
--- a/resources/views/components/table_view.blade.php
+++ b/resources/views/components/table_view.blade.php
@@ -26,9 +26,11 @@ $wire.on('close-preview-modal-{{ $getUniqueActionId() }}', () => { isOpen = fals
                 </tr>
             @endforeach
         </table>
-        <div>
-            <x-tables::pagination :paginator="$getRows()" :records-per-page-select-options="$this->getTable()->getRecordsPerPageSelectOptions()" />
-        </div>
+        @if ($getRows() instanceof \Illuminate\Pagination\LengthAwarePaginator)
+            <div>
+                <x-tables::pagination :paginator="$getRows()" :records-per-page-select-options="$this->getTable()->getRecordsPerPageSelectOptions()" />
+            </div>
+        @endif
     </div>
     <x-slot name="footer">
         @foreach ($getFooterActions() as $action)

--- a/resources/views/components/table_view.blade.php
+++ b/resources/views/components/table_view.blade.php
@@ -26,7 +26,7 @@ $wire.on('close-preview-modal-{{ $getUniqueActionId() }}', () => { isOpen = fals
                 </tr>
             @endforeach
         </table>
-        @if ($getRows() instanceof \Illuminate\Pagination\LengthAwarePaginator)
+        @if ($getExport()->getPaginator() !== null)
             <div>
                 <x-tables::pagination :paginator="$getRows()" :records-per-page-select-options="$this->getTable()->getRecordsPerPageSelectOptions()" />
             </div>

--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -75,13 +75,15 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
                     return [];
                 }
 
-                $currentPage = LengthAwarePaginator::resolveCurrentPage('exportPage');
+                if ($livewire->tableRecordsPerPage !== null) {
+                    $currentPage = LengthAwarePaginator::resolveCurrentPage('exportPage');
+                    
+                    $paginator = new LengthAwarePaginator($records->forPage($currentPage, $livewire->tableRecordsPerPage), $records->count(), $livewire->tableRecordsPerPage, $currentPage, [
+                        'pageName' => 'exportPage',
+                    ]);
 
-                $paginator = new LengthAwarePaginator($records->forPage($currentPage, $livewire->tableRecordsPerPage), $records->count(), $livewire->tableRecordsPerPage, $currentPage, [
-                    'pageName' => 'exportPage',
-                ]);
-
-                $action->paginator($paginator);
+                    $action->paginator($paginator);
+                }
 
                 return FilamentExport::getFormComponents($action);
             })

--- a/src/Actions/FilamentExportHeaderAction.php
+++ b/src/Actions/FilamentExportHeaderAction.php
@@ -76,7 +76,9 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
                     return [];
                 }
 
-                $action->paginator($action->getTableQuery()->paginate($livewire->tableRecordsPerPage, ['*'], 'exportPage'));
+                if ($livewire->tableRecordsPerPage !== null) {
+                  $action->paginator($action->getTableQuery()->paginate($livewire->tableRecordsPerPage, ['*'], 'exportPage'));
+                }
 
                 return FilamentExport::getFormComponents($action);
             })

--- a/src/Components/TableView.php
+++ b/src/Components/TableView.php
@@ -63,7 +63,7 @@ class TableView extends Component
 
     public function filteredColumns(array $columns): static
     {
-        if (count($columns) == 0) {
+        if (count($columns) === 0) {
             return $this;
         }
 
@@ -79,7 +79,7 @@ class TableView extends Component
 
     public function additionalColumns(array $additionalColumns): static
     {
-        if (count($additionalColumns) == 0) {
+        if (count($additionalColumns) === 0) {
             return $this;
         }
 
@@ -110,13 +110,15 @@ class TableView extends Component
         return $this->getExport()->getAllColumns();
     }
 
-    public function getRows(): LengthAwarePaginator
+    public function getRows(): Collection|LengthAwarePaginator
     {
         $paginator = $this
             ->getExport()
             ->getPaginator();
 
-        $paginator->getCollection()->transform(function ($row, $key) {
+        $collection = $paginator !== null ? $paginator->getCollection() : $this->getExport()->getData();
+
+        $collection->transform(function ($row, $key) {
             $data = [];
 
             foreach ($this->getAllColumns() as $column) {
@@ -132,7 +134,7 @@ class TableView extends Component
             return $data;
         });
 
-        return $paginator;
+        return $paginator !== null ? $paginator : $collection;
     }
 
     public function getExportAction(): Action

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -202,7 +202,7 @@ class FilamentExport
 
         $extraColumns = collect($action->getWithColumns());
 
-        if($extraColumns->isNotEmpty()) {
+        if ($extraColumns->isNotEmpty()) {
             $columns = $columns->merge($extraColumns);
         }
 
@@ -216,12 +216,16 @@ class FilamentExport
             $export = FilamentExport::make()
                 ->filteredColumns($data['filter_columns'] ?? [])
                 ->additionalColumns($data['additional_columns'] ?? [])
-                ->data(collect())
                 ->table($action->getTable())
                 ->extraViewData($action->getExtraViewData())
                 ->withColumns($action->getWithColumns())
-                ->paginator($action->getPaginator())
                 ->csvDelimiter($action->getCsvDelimiter());
+
+            if ($paginator = $action->getPaginator()) {
+                $export->paginator($paginator)->data(collect());
+            } else {
+                $export->data($action->getRecords());
+            }
 
             $component
                 ->export($export)
@@ -240,8 +244,13 @@ class FilamentExport
             ->data(collect())
             ->extraViewData($action->getExtraViewData())
             ->withColumns($action->getWithColumns())
-            ->paginator($action->getPaginator())
             ->csvDelimiter($action->getCsvDelimiter());
+
+          if ($paginator = $action->getPaginator()) {
+              $initialExport->paginator($paginator)->data(collect());
+          } else {
+              $initialExport->data($action->getRecords());
+          }
 
         return [
             \Filament\Forms\Components\TextInput::make('file_name')


### PR DESCRIPTION
Hey there! I wanted to propose this PR to add support to non-paginated tables.

I was working on a page with a small table, where I have disabled pagination using the following filament's function:

```php
protected function isTablePaginationEnabled(): bool
{
    return false;
}
```
I realized that the export functionality only works for tables with pagination enabled. I've figured out a way to support both paginated and non-paginated tables.

- **Small Note**: I'm checking if `$livewire->tableRecordsPerPage` is nullable because it sets the pagination records. By skipping this step, it makes `$action->paginator` nullable, and throughout the code, we can check if table pagination is enabled.

Please let me know if you have a better approach. Also, feel free to make any changes as you need to.

Thank you!