### PR TITLE
Feature disable table columns on export

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ FilamentExportBulkAction::make('export')
     ->disableFileName() // Disable file name input
     ->disableFileNamePrefix() // Disable file name prefix
     ->disablePreview() // Disable export preview
+    ->disableTableColumns() // Disable table columns in the export
     ->withHiddenColumns() //Show the columns which are toggled hidden
     ->fileNameFieldLabel('File Name') // Label for file name input
     ->formatFieldLabel('Format') // Label for format input

--- a/src/Actions/Concerns/CanDisableTableColumns.php
+++ b/src/Actions/Concerns/CanDisableTableColumns.php
@@ -6,7 +6,7 @@ trait CanDisableTableColumns
 {
     protected bool $isTableColumnsDisabled = false;
 
-    public function disableTableColumns(bool $condition = false): static
+    public function disableTableColumns(bool $condition = true): static
     {
         $this->isTableColumnsDisabled = $condition;
 

--- a/src/Actions/Concerns/CanDisableTableColumns.php
+++ b/src/Actions/Concerns/CanDisableTableColumns.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Actions\Concerns;
+
+trait CanDisableTableColumns
+{
+    protected bool $isTableColumnsDisabled = false;
+
+    public function disableTableColumns(bool $condition = false): static
+    {
+        $this->isTableColumnsDisabled = $condition;
+
+        return $this;
+    }
+
+    public function isTableColumnsDisabled(): bool
+    {
+        return $this->isTableColumnsDisabled;
+    }
+}

--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -8,6 +8,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileNamePrefix;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFilterColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFormats;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableTableColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDownloadDirect;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraViewData;
@@ -40,6 +41,7 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
     use CanDisableFilterColumns;
     use CanDisableFormats;
     use CanDisablePreview;
+    use CanDisableTableColumns;
     use CanDownloadDirect;
     use CanHaveExtraColumns;
     use CanHaveExtraViewData;

--- a/src/Actions/FilamentExportHeaderAction.php
+++ b/src/Actions/FilamentExportHeaderAction.php
@@ -8,6 +8,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFileNamePrefix;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFilterColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFormats;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableTableColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDownloadDirect;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraViewData;
@@ -40,6 +41,7 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
     use CanDisableFilterColumns;
     use CanDisableFormats;
     use CanDisablePreview;
+    use CanDisableTableColumns;
     use CanDownloadDirect;
     use CanHaveExtraColumns;
     use CanHaveExtraViewData;

--- a/src/Concerns/CanDisableTableColumns.php
+++ b/src/Concerns/CanDisableTableColumns.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait CanDisableTableColumns
+{
+    protected bool $isTableColumnsDisabled = false;
+
+    public function disableTableColumns(bool $condition = false): static
+    {
+        $this->isTableColumnsDisabled = $condition;
+
+        return $this;
+    }
+
+    public function isTableColumnsDisabled(): bool
+    {
+        return $this->isTableColumnsDisabled;
+    }
+}

--- a/src/Concerns/CanDisableTableColumns.php
+++ b/src/Concerns/CanDisableTableColumns.php
@@ -8,7 +8,7 @@ trait CanDisableTableColumns
 {
     protected bool $isTableColumnsDisabled = false;
 
-    public function disableTableColumns(bool $condition = false): static
+    public function disableTableColumns(bool $condition = true): static
     {
         $this->isTableColumnsDisabled = $condition;
 


### PR DESCRIPTION
With these changes, it is possible to remove the default columns from the table from the export if you do not want to export data from the table view. If you turn off the default table columns, you can also set up a custom order of columns using the `withColumns` methods.

Below is an example of how it can be used:

```php
FilamentExportBulkAction::make('export_selected')
            ->label(__('Export selected'))
            ->disableTableColumns(true)
            ->withColumns([
                TextColumn::make('uid'),
                TextColumn::make('group')
                ]
            );
```