### PR TITLE
Fix error when exporting all records

### DIFF
--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -79,7 +79,12 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
 
                 $currentPage = LengthAwarePaginator::resolveCurrentPage('exportPage');
 
-                $paginator = new LengthAwarePaginator($records->forPage($currentPage, $livewire->tableRecordsPerPage), $records->count(), $livewire->tableRecordsPerPage, $currentPage, [
+                $totalRecordsToExport = $livewire->tableRecordsPerPage;
+                if ($livewire->tableRecordsPerPage === 'all') {
+                    $totalRecordsToExport = $records->count();
+                }
+
+                $paginator = new LengthAwarePaginator($records->forPage($currentPage, $totalRecordsToExport), $records->count(), $totalRecordsToExport, $currentPage, [
                     'pageName' => 'exportPage',
                 ]);
 


### PR DESCRIPTION
If you choose 'all' in the filament table and then select one or more rows for export, you will receive the following error message:

```
Unsupported operand types: string * int
```

With this fix, at the time of export, in the case of the 'all' option, it calculates the number of records in the collection to prevent the error.