### PR TITLE
Column formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ FilamentExportBulkAction::make('export')
     ->csvDelimiter(',') // Delimiter for csv files
     ->modifyExcelWriter(fn (SimpleExcelWriter $writer) => $writer->nameCurrentSheet('Sheet')) // Modify SimpleExcelWriter before download
     ->modifyPdfWriter(fn (\Barryvdh\DomPDF\PDF|\Barryvdh\Snappy\PdfWrapper $writer) => $writer->setPaper('a4', 'landscape')) // Modify DomPdf or Snappy writer before download
+    ->formatStates([
+        'name' => fn (?Model $record) => strtoupper($record->name),
+    ]) // Manually format states for a specific column
 ```
 You can also use default bulk action and header action functions to customize actions.
 

--- a/src/Actions/Concerns/CanFormatStates.php
+++ b/src/Actions/Concerns/CanFormatStates.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Actions\Concerns;
+
+trait CanFormatStates
+{
+    protected $formatStates = [];
+
+    public function formatStates(array $functions = []): static
+    {
+        $this->formatStates = $functions;
+
+        return $this;
+    }
+
+    public function getFormatStates(): array
+    {
+        return $this->formatStates;
+    }
+}

--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -10,6 +10,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFormats;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableTableColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDownloadDirect;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanFormatStates;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraViewData;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanModifyWriters;
@@ -43,6 +44,7 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
     use CanDisablePreview;
     use CanDisableTableColumns;
     use CanDownloadDirect;
+    use CanFormatStates;
     use CanHaveExtraColumns;
     use CanHaveExtraViewData;
     use CanModifyWriters;

--- a/src/Actions/FilamentExportHeaderAction.php
+++ b/src/Actions/FilamentExportHeaderAction.php
@@ -64,6 +64,18 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
     use HasTimeFormat;
     use HasUniqueActionId;
 
+    protected $formatColumns = [];
+
+    public function formatColumns(array $array = []): static
+    {
+        $this->formatColumns = $array;
+        return $this;
+    }
+
+    public function getformatColumns() : array {
+        return $this->formatColumns;
+    }
+    
     protected function setUp(): void
     {
         parent::setUp();
@@ -90,7 +102,7 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
 
                 $records = $action->getRecords();
 
-                return FilamentExport::callDownload($action, $records, $data);
+                return FilamentExport::callDownload($action, $records, $data, $action->getformatColumns());
             });
     }
 }

--- a/src/Actions/FilamentExportHeaderAction.php
+++ b/src/Actions/FilamentExportHeaderAction.php
@@ -10,6 +10,7 @@ use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableFormats;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisablePreview;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDisableTableColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanDownloadDirect;
+use AlperenErsoy\FilamentExport\Actions\Concerns\CanFormatStates;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraColumns;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanHaveExtraViewData;
 use AlperenErsoy\FilamentExport\Actions\Concerns\CanModifyWriters;
@@ -43,6 +44,7 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
     use CanDisablePreview;
     use CanDisableTableColumns;
     use CanDownloadDirect;
+    use CanFormatStates;
     use CanHaveExtraColumns;
     use CanHaveExtraViewData;
     use CanModifyWriters;
@@ -64,18 +66,6 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
     use HasTimeFormat;
     use HasUniqueActionId;
 
-    protected $formatColumns = [];
-
-    public function formatColumns(array $array = []): static
-    {
-        $this->formatColumns = $array;
-        return $this;
-    }
-
-    public function getformatColumns() : array {
-        return $this->formatColumns;
-    }
-    
     protected function setUp(): void
     {
         parent::setUp();
@@ -102,7 +92,7 @@ class FilamentExportHeaderAction extends \Filament\Tables\Actions\Action
 
                 $records = $action->getRecords();
 
-                return FilamentExport::callDownload($action, $records, $data, $action->getformatColumns());
+                return FilamentExport::callDownload($action, $records, $data);
             });
     }
 }

--- a/src/Components/TableView.php
+++ b/src/Components/TableView.php
@@ -128,7 +128,7 @@ class TableView extends Component
                     continue;
                 }
 
-                $data[$column->getName()] = FilamentExport::getColumnState($this->getExport()->getTable(), $column, $row, $key);
+                $data[$column->getName()] = FilamentExport::getColumnState($this->getExport()->getTable(), $column, $row, $key, $this->getExport()->getFormatStates());
             }
 
             return $data;

--- a/src/Concerns/CanFormatStates.php
+++ b/src/Concerns/CanFormatStates.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AlperenErsoy\FilamentExport\Concerns;
+
+trait CanFormatStates
+{
+    protected $formatStates = [];
+
+    public function formatStates(array $functions = []): static
+    {
+        $this->formatStates = $functions;
+
+        return $this;
+    }
+
+    public function getFormatStates(): array
+    {
+        return $this->formatStates;
+    }
+}

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -2,6 +2,7 @@
 
 namespace AlperenErsoy\FilamentExport;
 
+
 use AlperenErsoy\FilamentExport\Actions\FilamentExportBulkAction;
 use AlperenErsoy\FilamentExport\Actions\FilamentExportHeaderAction;
 use AlperenErsoy\FilamentExport\Components\TableView;
@@ -21,6 +22,7 @@ use AlperenErsoy\FilamentExport\Concerns\HasPageOrientation;
 use AlperenErsoy\FilamentExport\Concerns\HasPaginator;
 use AlperenErsoy\FilamentExport\Concerns\HasTable;
 use Carbon\Carbon;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\ViewColumn;
@@ -49,6 +51,7 @@ class FilamentExport
     use HasPageOrientation;
     use HasPaginator;
     use HasTable;
+    use EvaluatesClosures;
 
     public const DEFAULT_FORMATS = [
         'xlsx' => 'XLSX',
@@ -352,7 +355,11 @@ class FilamentExport
 
                         $format_col = data_get($format_columns, $column_name);
                         if ($format_col) {
-                            $state = $this->evaluate($format_col);
+                            $state = $this->evaluate($format_col,[
+                                'record' => $record,
+                                'state'  => $record->{$column->getName()},
+                                'column' => $column,
+                            ]);
                         } else {
                             // is in the array but is not a Closure or value so return raw value
                             $state = (string)$record->{$column->getName()};

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -8,6 +8,7 @@ use AlperenErsoy\FilamentExport\Actions\FilamentExportHeaderAction;
 use AlperenErsoy\FilamentExport\Components\TableView;
 use AlperenErsoy\FilamentExport\Concerns\CanDisableTableColumns;
 use AlperenErsoy\FilamentExport\Concerns\CanFilterColumns;
+use AlperenErsoy\FilamentExport\Concerns\CanFormatStates;
 use AlperenErsoy\FilamentExport\Concerns\CanHaveAdditionalColumns;
 use AlperenErsoy\FilamentExport\Concerns\CanHaveExtraColumns;
 use AlperenErsoy\FilamentExport\Concerns\CanHaveExtraViewData;
@@ -37,6 +38,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FilamentExport
 {
     use CanFilterColumns;
+    use CanFormatStates;
     use CanHaveAdditionalColumns;
     use CanHaveExtraColumns;
     use CanHaveExtraViewData;
@@ -51,16 +53,13 @@ class FilamentExport
     use HasPageOrientation;
     use HasPaginator;
     use HasTable;
-    use EvaluatesClosures;
 
     public const DEFAULT_FORMATS = [
         'xlsx' => 'XLSX',
         'csv' => 'CSV',
         'pdf' => 'PDF',
     ];
-    
-    protected $formatColumns = [];
-    
+
     public static function make(): static
     {
         $static = app(static::class);
@@ -213,7 +212,7 @@ class FilamentExport
             $columns = $action->shouldShowHiddenColumns() ? $action->getTable()->getColumns() : $action->getTable()->getVisibleColumns();
         }
         $columns = $action->shouldShowHiddenColumns() ? $action->getTable()->getColumns() : $action->getTable()->getVisibleColumns();
-      
+
         $columns = collect($columns);
 
         $extraColumns = collect($action->getWithColumns());
@@ -240,7 +239,8 @@ class FilamentExport
                 ->extraViewData($action->getExtraViewData())
                 ->withColumns($action->getWithColumns())
                 ->paginator($action->getPaginator())
-                ->csvDelimiter($action->getCsvDelimiter());
+                ->csvDelimiter($action->getCsvDelimiter())
+                ->formatStates($action->getFormatStates());
 
 
             if ($data['table_view'] == 'print-' . $action->getUniqueActionId()) {
@@ -265,7 +265,8 @@ class FilamentExport
             ->extraViewData($action->getExtraViewData())
             ->withColumns($action->getWithColumns())
             ->paginator($action->getPaginator())
-            ->csvDelimiter($action->getCsvDelimiter());
+            ->csvDelimiter($action->getCsvDelimiter())
+            ->formatStates($action->getFormatStates());
 
         return [
             \Filament\Forms\Components\TextInput::make('file_name')
@@ -305,7 +306,7 @@ class FilamentExport
         ];
     }
 
-    public static function callDownload(FilamentExportHeaderAction | FilamentExportBulkAction $action, Collection $records, array $data, array $formatColumns = [])
+    public static function callDownload(FilamentExportHeaderAction | FilamentExportBulkAction $action, Collection $records, array $data)
     {
         return FilamentExport::make()
             ->fileName($data['file_name'] ?? $action->getFileName())
@@ -323,7 +324,7 @@ class FilamentExport
             ->csvDelimiter($action->getCsvDelimiter())
             ->modifyExcelWriter($action->getModifyExcelWriter())
             ->modifyPdfWriter($action->getModifyPdfWriter())
-            ->formatColumns($formatColumns)
+            ->formatStates($action->getFormatStates())
             ->download();
     }
 
@@ -341,35 +342,14 @@ class FilamentExport
         $items = [];
 
         $columns = $this->getAllColumns();
-        $format_columns  = $this->getFormatColumns();
+
+        $formatStates  = $this->getFormatStates();
 
         foreach ($records as $index => $record) {
             $item = [];
+
             foreach ($columns as $column) {
-
-                if(!empty($format_columns)) {
-                    
-                    $column_name = $column->getName();
-                    
-                    if(array_key_exists($column_name, $format_columns) || in_array($column_name, $format_columns)) {
-
-                        $format_col = data_get($format_columns, $column_name);
-                        if ($format_col) {
-                            $state = $this->evaluate($format_col,[
-                                'record' => $record,
-                                'state'  => $record->{$column->getName()},
-                                'column' => $column,
-                            ]);
-                        } else {
-                            // is in the array but is not a Closure or value so return raw value
-                            $state = (string)$record->{$column->getName()};
-                        }
-                        $item[ $column->getName() ] = (string) $state;
-                        continue;
-                    }
-                }
-                
-                $state = self::getColumnState($this->getTable(), $column, $record, $index);
+                $state = self::getColumnState($this->getTable(), $column, $record, $index, $formatStates);
 
                 $item[$column->getName()] = (string) $state;
             }
@@ -379,7 +359,7 @@ class FilamentExport
         return $items;
     }
 
-    public static function getColumnState(Table $table, Column $column, Model $record, int $index): ?string
+    public static function getColumnState(Table $table, Column $column, Model $record, int $index, array $formatStates): ?string
     {
         $column->rowLoop((object) [
             'index' => $index,
@@ -389,6 +369,31 @@ class FilamentExport
         $column->record($record);
 
         $column->table($table);
+
+        if (array_key_exists($column->getName(), $formatStates) && $formatStates[$column->getName()] instanceof \Closure) {
+            $closure = $formatStates[$column->getName()];
+
+            $dependencies = [];
+
+            foreach ((new \ReflectionFunction($closure))->getParameters() as $parameter) {
+                switch ($parameter->getName()) {
+                    case 'table':
+                        $dependencies[] = $table;
+                        break;
+                    case 'column':
+                        $dependencies[] = $column;
+                        break;
+                    case 'record':
+                        $dependencies[] = $record;
+                        break;
+                    case 'index':
+                        $dependencies[] = $index;
+                        break;
+                }
+            }
+
+            return $closure(...$dependencies);
+        }
 
         $state = in_array(\Filament\Tables\Columns\Concerns\CanFormatState::class, class_uses($column)) ? $column->formatState($column->getState()) : $column->getState();
 
@@ -402,15 +407,4 @@ class FilamentExport
 
         return $state;
     }
-
-    public function formatColumns(array $array = []): static
-    {
-        $this->formatColumns = $array;
-        return $this;
-    }
-
-    public function getformatColumns() : array {
-        return $this->formatColumns;
-    }
-    
 }


### PR DESCRIPTION
Added ability to format the column data before exporting CSV.

new method `->formatColumns()` on the FilamentExportHeaderAction

can be passed any array of column names or mix of column names and closures.

if just a column name is passed the raw value is exported.

## Example usage
```php
FilamentExportHeaderAction::make('export')->label(__('Export'))
                    ->formatColumns([
                        'status', // will just return raw value
                        'numbers' => fn(Customer $record): string => $record->numbers()->where('status', Number::STATUS_ACTIVE)->count() . ' / ' . $record->numbers()->where('status', Number::STATUS_DISABLED)->count(),
                    ])
```