### PR TITLE
Fix export with all and specific selection

### DIFF
--- a/src/Actions/FilamentExportBulkAction.php
+++ b/src/Actions/FilamentExportBulkAction.php
@@ -80,8 +80,9 @@ class FilamentExportBulkAction extends \Filament\Tables\Actions\BulkAction
                 }
 
                 $currentPage = LengthAwarePaginator::resolveCurrentPage('exportPage');
+                $perPage = $livewire->tableRecordsPerPage === 'all' ? $records->count() : $livewire->tableRecordsPerPage;
 
-                $paginator = new LengthAwarePaginator($records->forPage($currentPage, $livewire->tableRecordsPerPage), $records->count(), $livewire->tableRecordsPerPage, $currentPage, [
+                $paginator = new LengthAwarePaginator($records->forPage($currentPage, $perPage), $records->count(), $perPage, $currentPage, [
                     'pageName' => 'exportPage',
                 ]);
 


### PR DESCRIPTION
When you attempt to export a specific selection but have chosen to view all records in the table, you encounter the error: Unsupported operand types: string * int.

This fix resolves the issue by converting "all" to the number of records found in the SQL query. After this change, the export functions correctly.

See the image below for an example of how the export is performed. When you click on `exported selected` you will get the error.

<img width="1278" alt="Scherm­afbeelding 2024-10-10 om 22 35 53" src="https://github.com/user-attachments/assets/75941aa0-8545-4f42-85d6-bfd96ed6c83b">
